### PR TITLE
Make compatible with moor 4.3.0

### DIFF
--- a/example/lib/db/my_db.g.dart
+++ b/example/lib/db/my_db.g.dart
@@ -28,27 +28,22 @@ class Todo extends DataClass implements Insertable<Todo> {
   factory Todo.fromData(Map<String, dynamic> data, GeneratedDatabase db,
       {String? prefix}) {
     final effectivePrefix = prefix ?? '';
-    final intType = db.typeSystem.forDartType<int>();
-    final stringType = db.typeSystem.forDartType<String>();
-    final dateTimeType = db.typeSystem.forDartType<DateTime>();
-    final boolType = db.typeSystem.forDartType<bool>();
-    final doubleType = db.typeSystem.forDartType<double>();
-    final uint8ListType = db.typeSystem.forDartType<Uint8List>();
     return Todo(
-      id: intType.mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
-      title:
-          stringType.mapFromDatabaseResponse(data['${effectivePrefix}title'])!,
-      content:
-          stringType.mapFromDatabaseResponse(data['${effectivePrefix}body'])!,
-      category:
-          intType.mapFromDatabaseResponse(data['${effectivePrefix}category']),
-      date:
-          dateTimeType.mapFromDatabaseResponse(data['${effectivePrefix}date'])!,
-      completed: boolType
+      id: const IntType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
+      title: const StringType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}title'])!,
+      content: const StringType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}body'])!,
+      category: const IntType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}category']),
+      date: const DateTimeType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}date'])!,
+      completed: const BoolType()
           .mapFromDatabaseResponse(data['${effectivePrefix}completed'])!,
-      realColumn: doubleType
+      realColumn: const RealType()
           .mapFromDatabaseResponse(data['${effectivePrefix}real_column'])!,
-      blobColumn: uint8ListType
+      blobColumn: const BlobType()
           .mapFromDatabaseResponse(data['${effectivePrefix}blob_column'])!,
     );
   }
@@ -162,7 +157,7 @@ class Todo extends DataClass implements Insertable<Todo> {
                           $mrjc(
                               realColumn.hashCode, blobColumn.hashCode))))))));
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       identical(this, other) ||
       (other is Todo &&
           other.id == this.id &&
@@ -489,28 +484,29 @@ class User extends DataClass implements Insertable<User> {
   factory User.fromData(Map<String, dynamic> data, GeneratedDatabase db,
       {String? prefix}) {
     final effectivePrefix = prefix ?? '';
-    final intType = db.typeSystem.forDartType<int>();
-    final stringType = db.typeSystem.forDartType<String>();
     return User(
-      id: intType.mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
-      firstName: stringType
+      id: const IntType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
+      firstName: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}first_name'])!,
-      lastName: stringType
+      lastName: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}last_name'])!,
-      age: intType.mapFromDatabaseResponse(data['${effectivePrefix}age'])!,
-      zipcode: stringType
+      age: const IntType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}age'])!,
+      zipcode: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}zipcode'])!,
-      city: stringType.mapFromDatabaseResponse(data['${effectivePrefix}city'])!,
-      adress1: stringType
+      city: const StringType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}city'])!,
+      adress1: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}adress1'])!,
-      adress2: stringType
+      adress2: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}adress2'])!,
-      country: stringType
+      country: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}country'])!,
-      phone:
-          stringType.mapFromDatabaseResponse(data['${effectivePrefix}phone'])!,
-      email:
-          stringType.mapFromDatabaseResponse(data['${effectivePrefix}email'])!,
+      phone: const StringType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}phone'])!,
+      email: const StringType()
+          .mapFromDatabaseResponse(data['${effectivePrefix}email'])!,
     );
   }
   @override
@@ -646,7 +642,7 @@ class User extends DataClass implements Insertable<User> {
                                       $mrjc(phone.hashCode,
                                           email.hashCode)))))))))));
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       identical(this, other) ||
       (other is User &&
           other.id == this.id &&

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.0.0"
+    version: "21.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   analyzer_plugin_fork:
     dependency: transitive
     description:
@@ -290,21 +290,21 @@ packages:
       name: moor
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.1"
+    version: "4.3.0"
   moor_db_viewer:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.1.0"
   moor_generator:
     dependency: "direct dev"
     description:
       name: moor_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.1"
+    version: "4.3.0"
   nested:
     dependency: transitive
     description:
@@ -477,7 +477,7 @@ packages:
       name: sqlparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.0"
+    version: "0.16.0"
   stack_trace:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  moor: ^4.2.1
+  moor: ^4.3.0
   sqlite3_flutter_libs: ^0.4.1
   path_provider: ^2.0.1
   path: ^1.8.0
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  moor_generator: ^4.2.1
+  moor_generator: ^4.3.0
   build_runner: ^1.12.2
 
 flutter:

--- a/lib/src/navigator/db_navigator.dart
+++ b/lib/src/navigator/db_navigator.dart
@@ -97,7 +97,7 @@ class DbViewerNavigatorState extends State<DbViewerNavigator> {
   void goToTableList() =>
       _navigationKey.currentState!.pushNamed(MoorTableListScreen.routeName);
 
-  void goToTableContentList(TableInfo<moor.Table, DataClass> table) {
+  void goToTableContentList(TableInfo<moor.Table, dynamic> table) {
     _navigationKey.currentState!.pushNamed(
       MoorTableContentListScreen.routeName,
       arguments: table,

--- a/lib/src/screen/moor_table_list_screen.dart
+++ b/lib/src/screen/moor_table_list_screen.dart
@@ -50,6 +50,6 @@ class _MoorTableListScreenState extends State<MoorTableListScreen>
   }
 
   @override
-  void goToTableDetail(TableInfo<moor.Table, DataClass> table) =>
+  void goToTableDetail(TableInfo<moor.Table, dynamic> table) =>
       DbViewerNavigator.of(context).goToTableContentList(table);
 }

--- a/lib/src/viewmodel/moor_table_list_viewer_viewmodel.dart
+++ b/lib/src/viewmodel/moor_table_list_viewer_viewmodel.dart
@@ -6,7 +6,7 @@ class MoorTableListViewerViewModel with ChangeNotifier {
   late MoorTableListViewerNavigator _navigator;
   late GeneratedDatabase _databaseAccessor;
 
-  late List<TableInfo<moor.Table, DataClass>> tables;
+  late List<TableInfo<moor.Table, dynamic>> tables;
 
   Future<void> init(MoorTableListViewerNavigator navigator,
       GeneratedDatabase databaseAccessor) async {
@@ -20,11 +20,11 @@ class MoorTableListViewerViewModel with ChangeNotifier {
     tables = _databaseAccessor.allTables.map((item) => item).toList();
   }
 
-  void onTableClicked(TableInfo<moor.Table, DataClass> table) {
+  void onTableClicked(TableInfo<moor.Table, dynamic> table) {
     _navigator.goToTableDetail(table);
   }
 }
 
 abstract class MoorTableListViewerNavigator {
-  void goToTableDetail(TableInfo<moor.Table, DataClass> table);
+  void goToTableDetail(TableInfo<moor.Table, dynamic> table);
 }

--- a/lib/src/widget/general/table_row_item.dart
+++ b/lib/src/widget/general/table_row_item.dart
@@ -3,7 +3,7 @@ import 'package:moor/moor.dart';
 import 'package:moor/moor.dart' as moor;
 
 class TableRowItem extends StatelessWidget {
-  final TableInfo<moor.Table, DataClass> table;
+  final TableInfo<moor.Table, dynamic> table;
   final VoidCallback onClick;
 
   const TableRowItem({

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       name: moor
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.1"
+    version: "4.3.0"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: moor_db_viewer
 description: A package to view your moor database in your own app with filtering and without the need of exporting your db file.
-version: 3.0.1
+version: 3.1.0
 homepage: https://github.com/vanlooverenkoen/moor_db_viewer
 
 environment:
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  moor: ^4.2.1
+  moor: ^4.3.0
   provider: ^5.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Hi!

Moor 4.3.0 caused a breaking change. Because moor now allows custom data classes 
starting with 4.3.0 the type List<TableInfo<Table, DataClass>> needs to be changed
to List<TableInfo<Table, dynamic>>. This PR does just that.

Also regenerates the example db and bumps version number.