### PR TITLE
Upgrade to use Drift v2

### DIFF
--- a/drift_db_viewer/example/android/app/src/main/AndroidManifest.xml
+++ b/drift_db_viewer/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="driftdbviewerexample"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/drift_db_viewer/example/android/app/src/main/kotlin/be/vanlooverenkoen/driftdbviewerexample/MainActivity.kt
+++ b/drift_db_viewer/example/android/app/src/main/kotlin/be/vanlooverenkoen/driftdbviewerexample/MainActivity.kt
@@ -3,7 +3,6 @@ package be.vanlooverenkoen.driftbviewerexample
 import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugins.GeneratedPluginRegistrant
 
 class MainActivity: FlutterActivity() {
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {

--- a/drift_db_viewer/example/lib/db/my_db.g.dart
+++ b/drift_db_viewer/example/lib/db/my_db.g.dart
@@ -3,10 +3,10 @@
 part of 'my_db.dart';
 
 // **************************************************************************
-// MoorGenerator
+// DriftDatabaseGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps, unnecessary_this
+// ignore_for_file: type=lint
 class Todo extends DataClass implements Insertable<Todo> {
   final int id;
   final String title;
@@ -16,7 +16,7 @@ class Todo extends DataClass implements Insertable<Todo> {
   final bool completed;
   final double realColumn;
   final Uint8List blobColumn;
-  Todo(
+  const Todo(
       {required this.id,
       required this.title,
       required this.content,
@@ -25,27 +25,6 @@ class Todo extends DataClass implements Insertable<Todo> {
       required this.completed,
       required this.realColumn,
       required this.blobColumn});
-  factory Todo.fromData(Map<String, dynamic> data, {String? prefix}) {
-    final effectivePrefix = prefix ?? '';
-    return Todo(
-      id: const IntType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
-      title: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}title'])!,
-      content: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}body'])!,
-      category: const IntType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}category']),
-      date: const DateTimeType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}date'])!,
-      completed: const BoolType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}completed'])!,
-      realColumn: const RealType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}real_column'])!,
-      blobColumn: const BlobType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}blob_column'])!,
-    );
-  }
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -53,7 +32,7 @@ class Todo extends DataClass implements Insertable<Todo> {
     map['title'] = Variable<String>(title);
     map['body'] = Variable<String>(content);
     if (!nullToAbsent || category != null) {
-      map['category'] = Variable<int?>(category);
+      map['category'] = Variable<int>(category);
     }
     map['date'] = Variable<DateTime>(date);
     map['completed'] = Variable<bool>(completed);
@@ -110,7 +89,7 @@ class Todo extends DataClass implements Insertable<Todo> {
           {int? id,
           String? title,
           String? content,
-          int? category,
+          Value<int?> category = const Value.absent(),
           DateTime? date,
           bool? completed,
           double? realColumn,
@@ -119,7 +98,7 @@ class Todo extends DataClass implements Insertable<Todo> {
         id: id ?? this.id,
         title: title ?? this.title,
         content: content ?? this.content,
-        category: category ?? this.category,
+        category: category.present ? category.value : this.category,
         date: date ?? this.date,
         completed: completed ?? this.completed,
         realColumn: realColumn ?? this.realColumn,
@@ -195,7 +174,7 @@ class TodosCompanion extends UpdateCompanion<Todo> {
     Expression<int>? id,
     Expression<String>? title,
     Expression<String>? content,
-    Expression<int?>? category,
+    Expression<int>? category,
     Expression<DateTime>? date,
     Expression<bool>? completed,
     Expression<double>? realColumn,
@@ -247,7 +226,7 @@ class TodosCompanion extends UpdateCompanion<Todo> {
       map['body'] = Variable<String>(content.value);
     }
     if (category.present) {
-      map['category'] = Variable<int?>(category.value);
+      map['category'] = Variable<int>(category.value);
     }
     if (date.present) {
       map['date'] = Variable<DateTime>(date.value);
@@ -281,56 +260,57 @@ class TodosCompanion extends UpdateCompanion<Todo> {
 }
 
 class $TodosTable extends Todos with TableInfo<$TodosTable, Todo> {
-  final GeneratedDatabase _db;
+  @override
+  final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $TodosTable(this._db, [this._alias]);
+  $TodosTable(this.attachedDatabase, [this._alias]);
   final VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int?> id = GeneratedColumn<int?>(
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
       'id', aliasedName, false,
-      type: const IntType(),
+      type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultConstraints: 'PRIMARY KEY AUTOINCREMENT');
   final VerificationMeta _titleMeta = const VerificationMeta('title');
   @override
-  late final GeneratedColumn<String?> title = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
       'title', aliasedName, false,
       additionalChecks:
           GeneratedColumn.checkTextLength(minTextLength: 6, maxTextLength: 32),
-      type: const StringType(),
+      type: DriftSqlType.string,
       requiredDuringInsert: true);
   final VerificationMeta _contentMeta = const VerificationMeta('content');
   @override
-  late final GeneratedColumn<String?> content = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
       'body', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   final VerificationMeta _categoryMeta = const VerificationMeta('category');
   @override
-  late final GeneratedColumn<int?> category = GeneratedColumn<int?>(
+  late final GeneratedColumn<int> category = GeneratedColumn<int>(
       'category', aliasedName, true,
-      type: const IntType(), requiredDuringInsert: false);
+      type: DriftSqlType.int, requiredDuringInsert: false);
   final VerificationMeta _dateMeta = const VerificationMeta('date');
   @override
-  late final GeneratedColumn<DateTime?> date = GeneratedColumn<DateTime?>(
+  late final GeneratedColumn<DateTime> date = GeneratedColumn<DateTime>(
       'date', aliasedName, false,
-      type: const IntType(), requiredDuringInsert: true);
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
   final VerificationMeta _completedMeta = const VerificationMeta('completed');
   @override
-  late final GeneratedColumn<bool?> completed = GeneratedColumn<bool?>(
+  late final GeneratedColumn<bool> completed = GeneratedColumn<bool>(
       'completed', aliasedName, false,
-      type: const BoolType(),
+      type: DriftSqlType.bool,
       requiredDuringInsert: true,
       defaultConstraints: 'CHECK (completed IN (0, 1))');
   final VerificationMeta _realColumnMeta = const VerificationMeta('realColumn');
   @override
-  late final GeneratedColumn<double?> realColumn = GeneratedColumn<double?>(
+  late final GeneratedColumn<double> realColumn = GeneratedColumn<double>(
       'real_column', aliasedName, false,
-      type: const RealType(), requiredDuringInsert: true);
+      type: DriftSqlType.double, requiredDuringInsert: true);
   final VerificationMeta _blobColumnMeta = const VerificationMeta('blobColumn');
   @override
-  late final GeneratedColumn<Uint8List?> blobColumn =
-      GeneratedColumn<Uint8List?>('blob_column', aliasedName, false,
-          type: const BlobType(), requiredDuringInsert: true);
+  late final GeneratedColumn<Uint8List> blobColumn = GeneratedColumn<Uint8List>(
+      'blob_column', aliasedName, false,
+      type: DriftSqlType.blob, requiredDuringInsert: true);
   @override
   List<GeneratedColumn> get $columns =>
       [id, title, content, category, date, completed, realColumn, blobColumn];
@@ -397,29 +377,37 @@ class $TodosTable extends Todos with TableInfo<$TodosTable, Todo> {
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
   Todo map(Map<String, dynamic> data, {String? tablePrefix}) {
-    return Todo.fromData(data,
-        prefix: tablePrefix != null ? '$tablePrefix.' : null);
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Todo(
+      id: attachedDatabase.options.types
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      title: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
+      content: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}body'])!,
+      category: attachedDatabase.options.types
+          .read(DriftSqlType.int, data['${effectivePrefix}category']),
+      date: attachedDatabase.options.types
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}date'])!,
+      completed: attachedDatabase.options.types
+          .read(DriftSqlType.bool, data['${effectivePrefix}completed'])!,
+      realColumn: attachedDatabase.options.types
+          .read(DriftSqlType.double, data['${effectivePrefix}real_column'])!,
+      blobColumn: attachedDatabase.options.types
+          .read(DriftSqlType.blob, data['${effectivePrefix}blob_column'])!,
+    );
   }
 
   @override
   $TodosTable createAlias(String alias) {
-    return $TodosTable(_db, alias);
+    return $TodosTable(attachedDatabase, alias);
   }
 }
 
 class EmptyTableData extends DataClass implements Insertable<EmptyTableData> {
   final int todoA;
   final int todoB;
-  EmptyTableData({required this.todoA, required this.todoB});
-  factory EmptyTableData.fromData(Map<String, dynamic> data, {String? prefix}) {
-    final effectivePrefix = prefix ?? '';
-    return EmptyTableData(
-      todoA: const IntType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}todo_a'])!,
-      todoB: const IntType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}todo_b'])!,
-    );
-  }
+  const EmptyTableData({required this.todoA, required this.todoB});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -528,19 +516,20 @@ class EmptyTableCompanion extends UpdateCompanion<EmptyTableData> {
 
 class $EmptyTableTable extends EmptyTable
     with TableInfo<$EmptyTableTable, EmptyTableData> {
-  final GeneratedDatabase _db;
+  @override
+  final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $EmptyTableTable(this._db, [this._alias]);
+  $EmptyTableTable(this.attachedDatabase, [this._alias]);
   final VerificationMeta _todoAMeta = const VerificationMeta('todoA');
   @override
-  late final GeneratedColumn<int?> todoA = GeneratedColumn<int?>(
+  late final GeneratedColumn<int> todoA = GeneratedColumn<int>(
       'todo_a', aliasedName, false,
-      type: const IntType(), requiredDuringInsert: true);
+      type: DriftSqlType.int, requiredDuringInsert: true);
   final VerificationMeta _todoBMeta = const VerificationMeta('todoB');
   @override
-  late final GeneratedColumn<int?> todoB = GeneratedColumn<int?>(
+  late final GeneratedColumn<int> todoB = GeneratedColumn<int>(
       'todo_b', aliasedName, false,
-      type: const IntType(), requiredDuringInsert: true);
+      type: DriftSqlType.int, requiredDuringInsert: true);
   @override
   List<GeneratedColumn> get $columns => [todoA, todoB];
   @override
@@ -571,13 +560,18 @@ class $EmptyTableTable extends EmptyTable
   Set<GeneratedColumn> get $primaryKey => {todoA, todoB};
   @override
   EmptyTableData map(Map<String, dynamic> data, {String? tablePrefix}) {
-    return EmptyTableData.fromData(data,
-        prefix: tablePrefix != null ? '$tablePrefix.' : null);
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return EmptyTableData(
+      todoA: attachedDatabase.options.types
+          .read(DriftSqlType.int, data['${effectivePrefix}todo_a'])!,
+      todoB: attachedDatabase.options.types
+          .read(DriftSqlType.int, data['${effectivePrefix}todo_b'])!,
+    );
   }
 
   @override
   $EmptyTableTable createAlias(String alias) {
-    return $EmptyTableTable(_db, alias);
+    return $EmptyTableTable(attachedDatabase, alias);
   }
 }
 
@@ -593,7 +587,7 @@ class User extends DataClass implements Insertable<User> {
   final String country;
   final String phone;
   final String email;
-  User(
+  const User(
       {required this.id,
       required this.firstName,
       required this.lastName,
@@ -605,33 +599,6 @@ class User extends DataClass implements Insertable<User> {
       required this.country,
       required this.phone,
       required this.email});
-  factory User.fromData(Map<String, dynamic> data, {String? prefix}) {
-    final effectivePrefix = prefix ?? '';
-    return User(
-      id: const IntType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
-      firstName: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}first_name'])!,
-      lastName: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}last_name'])!,
-      age: const IntType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}age'])!,
-      zipcode: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}zipcode'])!,
-      city: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}city'])!,
-      adress1: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}adress1'])!,
-      adress2: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}adress2'])!,
-      country: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}country'])!,
-      phone: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}phone'])!,
-      email: const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}email'])!,
-    );
-  }
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -924,66 +891,67 @@ class UsersCompanion extends UpdateCompanion<User> {
 }
 
 class $UsersTable extends Users with TableInfo<$UsersTable, User> {
-  final GeneratedDatabase _db;
+  @override
+  final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $UsersTable(this._db, [this._alias]);
+  $UsersTable(this.attachedDatabase, [this._alias]);
   final VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<int?> id = GeneratedColumn<int?>(
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
       'id', aliasedName, false,
-      type: const IntType(),
+      type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultConstraints: 'PRIMARY KEY AUTOINCREMENT');
   final VerificationMeta _firstNameMeta = const VerificationMeta('firstName');
   @override
-  late final GeneratedColumn<String?> firstName = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> firstName = GeneratedColumn<String>(
       'first_name', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   final VerificationMeta _lastNameMeta = const VerificationMeta('lastName');
   @override
-  late final GeneratedColumn<String?> lastName = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> lastName = GeneratedColumn<String>(
       'last_name', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   final VerificationMeta _ageMeta = const VerificationMeta('age');
   @override
-  late final GeneratedColumn<int?> age = GeneratedColumn<int?>(
+  late final GeneratedColumn<int> age = GeneratedColumn<int>(
       'age', aliasedName, false,
-      type: const IntType(), requiredDuringInsert: true);
+      type: DriftSqlType.int, requiredDuringInsert: true);
   final VerificationMeta _zipcodeMeta = const VerificationMeta('zipcode');
   @override
-  late final GeneratedColumn<String?> zipcode = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> zipcode = GeneratedColumn<String>(
       'zipcode', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   final VerificationMeta _cityMeta = const VerificationMeta('city');
   @override
-  late final GeneratedColumn<String?> city = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> city = GeneratedColumn<String>(
       'city', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   final VerificationMeta _adress1Meta = const VerificationMeta('adress1');
   @override
-  late final GeneratedColumn<String?> adress1 = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> adress1 = GeneratedColumn<String>(
       'adress1', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   final VerificationMeta _adress2Meta = const VerificationMeta('adress2');
   @override
-  late final GeneratedColumn<String?> adress2 = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> adress2 = GeneratedColumn<String>(
       'adress2', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   final VerificationMeta _countryMeta = const VerificationMeta('country');
   @override
-  late final GeneratedColumn<String?> country = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> country = GeneratedColumn<String>(
       'country', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   final VerificationMeta _phoneMeta = const VerificationMeta('phone');
   @override
-  late final GeneratedColumn<String?> phone = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> phone = GeneratedColumn<String>(
       'phone', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   final VerificationMeta _emailMeta = const VerificationMeta('email');
   @override
-  late final GeneratedColumn<String?> email = GeneratedColumn<String?>(
+  late final GeneratedColumn<String> email = GeneratedColumn<String>(
       'email', aliasedName, false,
-      type: const StringType(), requiredDuringInsert: true);
+      type: DriftSqlType.string, requiredDuringInsert: true);
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -1077,23 +1045,47 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
   User map(Map<String, dynamic> data, {String? tablePrefix}) {
-    return User.fromData(data,
-        prefix: tablePrefix != null ? '$tablePrefix.' : null);
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return User(
+      id: attachedDatabase.options.types
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      firstName: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}first_name'])!,
+      lastName: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}last_name'])!,
+      age: attachedDatabase.options.types
+          .read(DriftSqlType.int, data['${effectivePrefix}age'])!,
+      zipcode: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}zipcode'])!,
+      city: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}city'])!,
+      adress1: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}adress1'])!,
+      adress2: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}adress2'])!,
+      country: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}country'])!,
+      phone: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}phone'])!,
+      email: attachedDatabase.options.types
+          .read(DriftSqlType.string, data['${effectivePrefix}email'])!,
+    );
   }
 
   @override
   $UsersTable createAlias(String alias) {
-    return $UsersTable(_db, alias);
+    return $UsersTable(attachedDatabase, alias);
   }
 }
 
 abstract class _$MyDatabase extends GeneratedDatabase {
-  _$MyDatabase(QueryExecutor e) : super(SqlTypeSystem.defaultInstance, e);
+  _$MyDatabase(QueryExecutor e) : super(e);
   late final $TodosTable todos = $TodosTable(this);
   late final $EmptyTableTable emptyTable = $EmptyTableTable(this);
   late final $UsersTable users = $UsersTable(this);
   @override
-  Iterable<TableInfo> get allTables => allSchemaEntities.whereType<TableInfo>();
+  Iterable<TableInfo<Table, dynamic>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
   List<DatabaseSchemaEntity> get allSchemaEntities =>
       [todos, emptyTable, users];

--- a/drift_db_viewer/example/pubspec.lock
+++ b/drift_db_viewer/example/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "34.0.0"
+    version: "46.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "4.6.0"
   analyzer_plugin:
     dependency: transitive
     description:
       name: analyzer_plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0"
+    version: "0.11.1"
   args:
     dependency: transitive
     description:
@@ -49,35 +49,35 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.9"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.7"
+    version: "2.2.0"
   build_runner_core:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.3"
   db_viewer:
     dependency: transitive
     description:
@@ -182,35 +182,35 @@ packages:
       name: drift
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "2.0.1"
   drift_db_viewer:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.2"
+    version: "1.0.3"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "2.0.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   file:
     dependency: transitive
     description:
@@ -283,14 +283,14 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "4.6.0"
   logging:
     dependency: transitive
     description:
@@ -305,6 +305,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -339,14 +346,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.11"
   path_provider_android:
     dependency: transitive
     description:
@@ -423,7 +430,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.3"
   pub_semver:
     dependency: transitive
     description:
@@ -470,35 +477,35 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.7.2"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.3"
+    version: "0.5.9"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.19.2"
+    version: "0.23.0"
   stack_trace:
     dependency: transitive
     description:
@@ -540,7 +547,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.9"
   timing:
     dependency: transitive
     description:
@@ -561,7 +568,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   watcher:
     dependency: transitive
     description:
@@ -598,5 +605,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=2.17.0 <3.0.0"
+  flutter: ">=2.8.0"

--- a/drift_db_viewer/example/pubspec.yaml
+++ b/drift_db_viewer/example/pubspec.yaml
@@ -7,18 +7,18 @@ environment:
   sdk: ">=2.13.0 <3.0.0"
 
 dependencies:
-  drift: ^1.0.1
+  drift: ^2.0.1
   drift_db_viewer:
     path: ../
   flutter:
     sdk: flutter
-  sqlite3_flutter_libs: ^0.5.0
-  path_provider: ^2.0.2
-  path: ^1.8.0
+  sqlite3_flutter_libs: ^0.5.9
+  path_provider: ^2.0.11
+  path: ^1.8.1
 
 dev_dependencies:
-  build_runner: ^2.1.1
-  drift_dev: ^1.0.2
+  build_runner: ^2.2.0
+  drift_dev: ^2.0.0
   flutter_test:
     sdk: flutter
 

--- a/drift_db_viewer/lib/src/model/filter/drift_filter_data.dart
+++ b/drift_db_viewer/lib/src/model/filter/drift_filter_data.dart
@@ -10,8 +10,9 @@ import 'package:db_viewer/db_viewer.dart';
 
 class DriftFilterData extends FilterData {
   final TableInfo<drift.Table, dynamic> _table;
+  final SqlTypes _types;
 
-  DriftFilterData(this._table) : super();
+  DriftFilterData(this._table, this._types) : super();
 
   @override
   Map<String, bool> getSelectedColumns() {
@@ -30,23 +31,17 @@ class DriftFilterData extends FilterData {
     if (!_table.columnsByName.containsKey(columnName)) return null;
     final detail =
         _table.$columns.where((item) => item.$name == columnName).first;
-    if (detail is GeneratedColumn<String> ||
-        detail is GeneratedColumn<String?>) {
+    if (detail is GeneratedColumn<String>) {
       return StringWhereClause(columnName);
-    } else if (detail is GeneratedColumn<int> ||
-        detail is GeneratedColumn<int?>) {
+    } else if (detail is GeneratedColumn<int>) {
       return IntWhereClause(columnName);
-    } else if (detail is GeneratedColumn<DateTime> ||
-        detail is GeneratedColumn<DateTime?>) {
-      return DateWhereClause(columnName);
-    } else if (detail is GeneratedColumn<bool> ||
-        detail is GeneratedColumn<bool?>) {
-      return BoolWhereClause(columnName);
-    } else if (detail is GeneratedColumn<double> ||
-        detail is GeneratedColumn<double?>) {
+    } else if (detail is GeneratedColumn<DateTime>) {
+      return DateWhereClause(columnName, _types);
+    } else if (detail is GeneratedColumn<bool>) {
+      return BoolWhereClause(columnName, _types);
+    } else if (detail is GeneratedColumn<double>) {
       return DoubleWhereClause(columnName);
-    } else if (detail is GeneratedColumn<Uint8List> ||
-        detail is GeneratedColumn<Uint8List?>) {
+    } else if (detail is GeneratedColumn<Uint8List>) {
       return BlobWhereClause(columnName);
     } else {
       print('$detail is not yet supported');
@@ -54,5 +49,5 @@ class DriftFilterData extends FilterData {
   }
 
   @override
-  FilterData copy() => copyTo(DriftFilterData(_table));
+  FilterData copy() => copyTo(DriftFilterData(_table, _types));
 }

--- a/drift_db_viewer/lib/src/model/filter/where/bool_where_clause.dart
+++ b/drift_db_viewer/lib/src/model/filter/where/bool_where_clause.dart
@@ -3,23 +3,23 @@ import 'package:drift/drift.dart';
 
 class BoolWhereClause extends WhereClause {
   bool _value = true;
+  final SqlTypes _types;
 
   @override
   String get typeName => 'BOOL';
 
   bool get value => _value;
 
-  BoolWhereClause(String columnName) : super(columnName: columnName);
+  BoolWhereClause(String columnName, this._types) : super(columnName: columnName);
 
   @override
   String getSqlWhereClause() {
-    final boolType = BoolType();
-    return ' $columnName = ${boolType.mapToSqlVariable(_value)}';
+    return ' $columnName = ${_types.mapToSqlVariable(_value)}';
   }
 
   @override
   WhereClause copy() {
-    final whereClause = BoolWhereClause(columnName);
+    final whereClause = BoolWhereClause(columnName, _types);
     whereClause._value = _value;
     return whereClause;
   }

--- a/drift_db_viewer/lib/src/model/filter/where/date_where_clause.dart
+++ b/drift_db_viewer/lib/src/model/filter/where/date_where_clause.dart
@@ -5,6 +5,7 @@ import 'package:db_viewer/src/model/filter/where/where_clause.dart';
 class DateWhereClause extends WhereClause {
   DateWhereType _dateWhereType = DateWhereType.EQUALS;
 
+  final SqlTypes _types;
   late DateTime _date;
   late TimeOfDay _time;
 
@@ -22,7 +23,7 @@ class DateWhereClause extends WhereClause {
 
   DateWhereType get dateWhereType => _dateWhereType;
 
-  DateWhereClause(String columnName) : super(columnName: columnName) {
+  DateWhereClause(String columnName, this._types) : super(columnName: columnName) {
     final now = DateTime.now();
     _date = DateTime(now.year, now.month, now.day);
     _time = TimeOfDay(hour: now.hour, minute: now.minute);
@@ -32,8 +33,7 @@ class DateWhereClause extends WhereClause {
   String getSqlWhereClause() {
     final sqlDate =
         DateTime(date.year, date.month, date.day, time.hour, time.minute);
-    final dateTimeParser = DateTimeType();
-    final sqlValue = dateTimeParser.mapToSqlVariable(sqlDate);
+    final sqlValue = _types.mapToSqlVariable(sqlDate);
     if (dateWhereType == DateWhereType.BEFORE) {
       return ' $columnName < $sqlValue';
     } else if (dateWhereType == DateWhereType.EQUALS) {
@@ -46,7 +46,7 @@ class DateWhereClause extends WhereClause {
 
   @override
   WhereClause copy() {
-    final whereClause = DateWhereClause(columnName);
+    final whereClause = DateWhereClause(columnName, _types);
     whereClause._dateWhereType = _dateWhereType;
     whereClause._date = _date;
     whereClause._time = _time;

--- a/drift_db_viewer/pubspec.lock
+++ b/drift_db_viewer/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: drift
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "2.0.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -88,6 +88,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
@@ -95,6 +102,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -115,14 +129,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   provider:
     dependency: "direct main"
     description:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -134,14 +148,14 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.7.2"
   stack_trace:
     dependency: transitive
     description:
@@ -176,7 +190,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -190,7 +204,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.2.0"

--- a/drift_db_viewer/pubspec.yaml
+++ b/drift_db_viewer/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
 
 dependencies:
   db_viewer: ^1.0.3
-  drift: ^1.3.0
+  drift: ^2.0.1
   flutter:
     sdk: flutter
-  provider: ^6.0.2
+  provider: ^6.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
closes #53 

[Drift 2.0](https://pub.dev/packages/drift/changelog#200) was released yesterday with some breaking changes. This PR adapts the `drift_db_viewer` and `drift_db_viewer_example` to support these changes and work as expected.

Most notably:
- To support the latest `sqlite3_flutter_libs`, the Android embedding was upgraded to V2
- Migrate from SqlTypeSystem to using SqlTypes and DriftSqlType. For this purpose, the bool and datetime columns now get passed a reference to the SqlTypes object to perfrom the conversion, as does remapData in the viewer database class.

_Before merging, the version should probably be bumped up, and a note may have to be added to the readme_