### PR TITLE
Exporting of `DriftDbViewerDatabase`

### DIFF
--- a/drift_db_viewer/lib/drift_db_viewer.dart
+++ b/drift_db_viewer/lib/drift_db_viewer.dart
@@ -2,3 +2,4 @@ library drift_db_viewer;
 
 export 'src/screen/drift_db_viewer_widget.dart';
 export 'src/model/db/drift_db_viewer_database.dart';
+export 'src/widget/filter/where_widget.dart';

--- a/drift_db_viewer/lib/drift_db_viewer.dart
+++ b/drift_db_viewer/lib/drift_db_viewer.dart
@@ -2,4 +2,3 @@ library drift_db_viewer;
 
 export 'src/screen/drift_db_viewer_widget.dart';
 export 'src/model/db/drift_db_viewer_database.dart';
-export 'src/widget/filter/where_widget.dart';

--- a/drift_db_viewer/lib/drift_db_viewer.dart
+++ b/drift_db_viewer/lib/drift_db_viewer.dart
@@ -1,3 +1,4 @@
 library drift_db_viewer;
 
 export 'src/screen/drift_db_viewer_widget.dart';
+export 'src/model/db/drift_db_viewer_database.dart';

--- a/drift_db_viewer/lib/src/model/db/drift_db_viewer_database.dart
+++ b/drift_db_viewer/lib/src/model/db/drift_db_viewer_database.dart
@@ -4,13 +4,37 @@ import 'package:drift_db_viewer/src/model/filter/drift_filter_data.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:drift_db_viewer/src/widget/filter/where_widget.dart';
 
-class DriftDbViewerDatabase implements DbViewerDatabase {
+class DBHandler {
   final GeneratedDatabase _db;
+
+  DBHandler(this._db);
+
+  Iterable<TableInfo<Table, dynamic>> get allTables => _db.allTables;
+
+  SqlTypes get typeMapping => _db.typeMapping;
+
+  Selectable<QueryRow> customSelect(
+    String query, {
+    Set<ResultSetImplementation<dynamic, dynamic>> readsFrom = const {},
+    List<Variable<Object>> variables = const [],
+  }) =>
+      _db.customSelect(
+        query,
+        readsFrom: readsFrom,
+        variables: variables,
+      );
+
+  Future<void> customStatement(String query, [List<dynamic>? args]) =>
+      _db.customStatement(query, args);
+}
+
+class DriftDbViewerDatabase implements DbViewerDatabase {
+  final DBHandler _db;
   final _filterData = <String, FilterData>{};
 
   DriftDbViewerDatabase._(this._db);
 
-  static init(GeneratedDatabase db) =>
+  static init(DBHandler db) =>
       DbViewerDatabase.initDb(DriftDbViewerDatabase._(db));
 
   TableInfo<Table, dynamic>? _getTable(String tableName) {

--- a/drift_db_viewer/lib/src/model/db/drift_db_viewer_database.dart
+++ b/drift_db_viewer/lib/src/model/db/drift_db_viewer_database.dart
@@ -5,26 +5,26 @@ import 'package:flutter/src/widgets/framework.dart';
 import 'package:drift_db_viewer/src/widget/filter/where_widget.dart';
 
 class DriftDbViewerDatabase implements DbViewerDatabase {
-  final GeneratedDatabase db;
+  final GeneratedDatabase _db;
   final _filterData = <String, FilterData>{};
 
-  DriftDbViewerDatabase._(this.db);
+  DriftDbViewerDatabase._(this._db);
 
   static init(GeneratedDatabase db) =>
       DbViewerDatabase.initDb(DriftDbViewerDatabase._(db));
 
   //Entity Info
-  Iterable<TableInfo<Table, dynamic>> get tables => db.allTables;
+  Iterable<TableInfo<Table, dynamic>> get tables => _db.allTables;
 
   TableInfo<Table, dynamic>? getTable(String tableName) {
     final tables =
-        db.allTables.where((element) => element.actualTableName == tableName);
+        _db.allTables.where((element) => element.actualTableName == tableName);
     if (tables.isEmpty) return null;
     return tables.first;
   }
 
   List<String> get entityNames =>
-      db.allTables.map((e) => e.entityName).toList();
+      _db.allTables.map((e) => e.entityName).toList();
 
   @override
   List<String> getColumnNamesByEntityName(String tableName) =>
@@ -33,7 +33,7 @@ class DriftDbViewerDatabase implements DbViewerDatabase {
   @override
   List<Map<String, dynamic>> remapData(
       String tableName, List<Map<String, dynamic>> data) {
-    final SqlTypes types = db.typeMapping;
+    final SqlTypes types = _db.typeMapping;
     final table = getTable(tableName);
     if (table == null) return data;
     final correctData = <Map<String, dynamic>>[];
@@ -84,24 +84,24 @@ class DriftDbViewerDatabase implements DbViewerDatabase {
   @override
   Future<List<Map<String, dynamic>>> customSelect(String query,
       {Set<String>? fromEntityNames}) async {
-    final result = await db.customSelect(query).get();
+    final result = await _db.customSelect(query).get();
     return result.map((e) => e.data).toList();
   }
 
   @override
   Stream<List<Map<String, dynamic>>> customSelectStream(String query,
           {Set<String>? fromEntityNames}) =>
-      db.customSelect(query).map((item) => item.data).watch();
+      _db.customSelect(query).map((item) => item.data).watch();
 
   @override
   Future<void> runCustomStatement(String query) async =>
-      await db.customStatement(query);
+      await _db.customStatement(query);
 
   @override
   Stream<int> count(String tableName) {
     final table = getTable(tableName);
     if (table == null) return Stream.value(0);
-    final countStream = db.customSelect('SELECT COUNT(*) FROM ${tableName}',
+    final countStream = _db.customSelect('SELECT COUNT(*) FROM ${tableName}',
         readsFrom: {table}).watch();
     return countStream.map((data) => data.first.data['COUNT(*)']);
   }
@@ -111,7 +111,7 @@ class DriftDbViewerDatabase implements DbViewerDatabase {
   FilterData getFilterData(String tableName) {
     final table = getTable(tableName);
     if (table == null) throw ArgumentError('$tableName is not available');
-    return DriftFilterData(table, db.typeMapping);
+    return DriftFilterData(table, _db.typeMapping);
   }
 
   FilterData getCachedFilterData(String entityName) {

--- a/drift_db_viewer/lib/src/model/db/drift_db_viewer_database.dart
+++ b/drift_db_viewer/lib/src/model/db/drift_db_viewer_database.dart
@@ -13,10 +13,7 @@ class DriftDbViewerDatabase implements DbViewerDatabase {
   static init(GeneratedDatabase db) =>
       DbViewerDatabase.initDb(DriftDbViewerDatabase._(db));
 
-  //Entity Info
-  Iterable<TableInfo<Table, dynamic>> get tables => _db.allTables;
-
-  TableInfo<Table, dynamic>? getTable(String tableName) {
+  TableInfo<Table, dynamic>? _getTable(String tableName) {
     final tables =
         _db.allTables.where((element) => element.actualTableName == tableName);
     if (tables.isEmpty) return null;
@@ -28,13 +25,13 @@ class DriftDbViewerDatabase implements DbViewerDatabase {
 
   @override
   List<String> getColumnNamesByEntityName(String tableName) =>
-      getTable(tableName)?.columnsByName.keys.toList() ?? [];
+      _getTable(tableName)?.columnsByName.keys.toList() ?? [];
 
   @override
   List<Map<String, dynamic>> remapData(
       String tableName, List<Map<String, dynamic>> data) {
     final SqlTypes types = _db.typeMapping;
-    final table = getTable(tableName);
+    final table = _getTable(tableName);
     if (table == null) return data;
     final correctData = <Map<String, dynamic>>[];
     data.forEach((item) {
@@ -60,7 +57,7 @@ class DriftDbViewerDatabase implements DbViewerDatabase {
 
   @override
   String getType(String entityName, String columnName) {
-    final entity = getTable(entityName);
+    final entity = _getTable(entityName);
     if (entity == null) throw ArgumentError('Entity $entityName is not found');
     final column =
         entity.$columns.firstWhere((column) => column.$name == columnName);
@@ -99,7 +96,7 @@ class DriftDbViewerDatabase implements DbViewerDatabase {
 
   @override
   Stream<int> count(String tableName) {
-    final table = getTable(tableName);
+    final table = _getTable(tableName);
     if (table == null) return Stream.value(0);
     final countStream = _db.customSelect('SELECT COUNT(*) FROM ${tableName}',
         readsFrom: {table}).watch();
@@ -109,7 +106,7 @@ class DriftDbViewerDatabase implements DbViewerDatabase {
   //Filter Data
   @override
   FilterData getFilterData(String tableName) {
-    final table = getTable(tableName);
+    final table = _getTable(tableName);
     if (table == null) throw ArgumentError('$tableName is not available');
     return DriftFilterData(table, _db.typeMapping);
   }

--- a/drift_db_viewer/lib/src/screen/drift_db_viewer_widget.dart
+++ b/drift_db_viewer/lib/src/screen/drift_db_viewer_widget.dart
@@ -15,7 +15,7 @@ class DriftDbViewer extends StatefulWidget {
 class _DriftDbViewerState extends State<DriftDbViewer> {
   @override
   void initState() {
-    DriftDbViewerDatabase.init(widget.db);
+    DriftDbViewerDatabase.init(DBHandler(widget.db));
     super.initState();
   }
 


### PR DESCRIPTION
Hiding the `GeneratedDatabase` variable and exporting `DriftDbViewerDatabase` so that  https://github.com/simolus3/drift/issues/3185 can be fixed for the Drift DevTools extension to implement `DriftDbViewerDatabase` officially.