### PR TITLE
fix: improve table readability by adjusting columnSpacing

### DIFF
--- a/db_viewer/lib/src/screen/table_content_list_screen.dart
+++ b/db_viewer/lib/src/screen/table_content_list_screen.dart
@@ -78,7 +78,7 @@ class _TableContentListScreenState extends State<TableContentListScreen>
               child: SingleChildScrollView(
                 scrollDirection: Axis.horizontal,
                 child: DataTable(
-                  columnSpacing: 0,
+                  columnSpacing: 16,
                   columns: [
                     for (final item in viewModel.data[0].keys)
                       DataColumn(


### PR DESCRIPTION
### Description
I've been using the Drift DevTools extension to inspect my databases and noticed that the columns in the data table are too close to each other, making it hard to read when column names or data are long.

### Screenshots
<img width="800" height="558" alt="Group 1" src="https://github.com/user-attachments/assets/f798a6a7-5013-4eb3-8ec5-b9032a5e20bd" />

I confirmed that the extension renders the UI using drift_db_viewer by checking the implementation:
- [drift_devtools_extension](https://github.com/simolus3/drift/blob/develop/extras/drift_devtools_extension/lib/src/db_viewer/viewer.dart)

### Extension issue
- https://github.com/simolus3/drift/issues/3557

### Changes
I increased the columnSpacing of the DataTable from `0` to `16` in `table_content_list_screen.dart` to provide better visual separation between columns.

### Verification
#### Before
<img width="1078" height="514" alt="image" src="https://github.com/user-attachments/assets/4382a215-d647-4cf8-8950-02650aff23f5" />

#### After
<img width="1078" height="514" alt="image" src="https://github.com/user-attachments/assets/b77fd8c6-ba89-48d1-80d9-dda800afe92e" />


 